### PR TITLE
Updated MSSQL 2012 SP2, New Inventory and Vulnerability Definitions

### DIFF
--- a/repository/definitions/inventory/oval_com.dtcc.oval_def_2019.xml
+++ b/repository/definitions/inventory/oval_com.dtcc.oval_def_2019.xml
@@ -1,6 +1,6 @@
-<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:org.mitre.oval:def:29429" version="2">
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="inventory" id="oval:com.dtcc.oval:def:2019" version="0">
   <oval-def:metadata>
-    <oval-def:title>Microsoft SQL Server 2012 SP2 is installed</oval-def:title>
+    <oval-def:title>Microsoft SQL Server 2012 SP3 is installed</oval-def:title>
     <oval-def:affected family="windows">
       <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
       <oval-def:platform>Microsoft Windows 7</oval-def:platform>
@@ -12,23 +12,20 @@
       <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
       <oval-def:product>Microsoft SQL Server 2012</oval-def:product>
     </oval-def:affected>
-    <oval-def:reference ref_id="cpe:/a:microsoft:sql_server:2012:sp2" source="CPE" />
-    <oval-def:description>Microsoft SQL Server 2012 SP2 is installed</oval-def:description>
+    <oval-def:reference ref_id="cpe:/a:microsoft:sql_server:2012:sp3" source="CPE" />
+    <oval-def:description>Microsoft SQL Server 2012 SP3 is installed</oval-def:description>
     <oval-def:oval_repository>
       <oval-def:dates>
-        <oval-def:submitted date="2015-07-22T13:00:00">
-          <oval-def:contributor organization="SecPod Technologies">SecPod Team</oval-def:contributor>
+        <oval-def:submitted date="2016-12-07T00:00:00+08:00">
+          <oval-def:contributor organization="DTCC">Jeff Albert</oval-def:contributor>
         </oval-def:submitted>
-        <oval-def:status_change date="2015-07-23T11:09:50.234-04:00">DRAFT</oval-def:status_change>
-        <oval-def:status_change date="2015-08-10T04:00:55.072-04:00">INTERIM</oval-def:status_change>
-        <oval-def:status_change date="2015-12-22T12:30:00.000-05:00">ACCEPTED</oval-def:status_change>
       </oval-def:dates>
-      <oval-def:status>ACCEPTED</oval-def:status>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
       <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
     </oval-def:oval_repository>
   </oval-def:metadata>
   <oval-def:criteria operator="AND">
     <oval-def:extend_definition comment="Microsoft SQL Server 2012 is installed" definition_ref="oval:org.mitre.oval:def:15044" />
-    <oval-def:criterion comment="Check if SQL Server 2012 SP2 is installed" test_ref="oval:org.mitre.oval:tst:140967" />
+    <oval-def:criterion comment="Check if SQL Server 2012 SP3 is installed" test_ref="oval:com.dtcc.oval:tst:2019" />
   </oval-def:criteria>
 </oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.dtcc.oval_def_2309.xml
+++ b/repository/definitions/vulnerability/oval_com.dtcc.oval_def_2309.xml
@@ -1,0 +1,70 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.dtcc.oval:def:2309" version="0">
+  <oval-def:metadata>
+    <oval-def:title>SQL Server Agent Elevation of Privilege Vulnerability - CVE-2016-7253 (MS16-136)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:product>Microsoft SQL Server 2012</oval-def:product>
+      <oval-def:product>Microsoft SQL Server 2014</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-7253" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7253" source="CVE" />
+    <oval-def:description>The agent in Microsoft SQL Server 2012 SP2, 2012 SP3, 2014 SP1, 2014 SP2, and 2016 does not properly check the atxcore.dll ACL, which allows remote authenticated users to gain privileges via unspecified vectors, aka "SQL Server Agent Elevation of Privilege Vulnerability."</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2016-12-07T00:00:00+08:00">
+          <oval-def:contributor organization="DTCC">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="MS SQL Server+ vulnerable range" operator="OR">
+    <oval-def:criteria comment="Microsoft SQL Server 2012 SP2 + vulnerable range" operator="AND">
+      <oval-def:extend_definition comment="Microsoft SQL Server 2012 SP2 is installed" definition_ref="oval:org.mitre.oval:def:29429" />
+      <oval-def:criteria comment="Check for vulnerable range" operator="OR">
+        <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 11.0.5388.0" test_ref="oval:com.dtcc.oval:tst:23090" />
+        <oval-def:criteria comment="SQL Server 2012 SP2 CU15" operator="AND">
+          <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 11.0.5676.0" test_ref="oval:com.dtcc.oval:tst:23091" />
+          <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is greater than or equal to 11.0.5500.0" test_ref="oval:com.dtcc.oval:tst:23092" />
+        </oval-def:criteria>
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft SQL Server 2012 SP3 + vulnerable range" operator="AND">
+      <oval-def:extend_definition comment="Microsoft SQL Server 2012 SP3 is installed" definition_ref="oval:com.dtcc.oval:def:2019" />
+      <oval-def:criteria comment="Check for vulnerable range" operator="OR">
+        <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 11.0.6248.0" test_ref="oval:com.dtcc.oval:tst:23093" />
+        <oval-def:criteria comment="SQL Server 2012 SP3 CU6" operator="AND">
+          <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 11.0.6567.0" test_ref="oval:com.dtcc.oval:tst:23094" />
+          <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is greater than or equal to 11.0.6300.0" test_ref="oval:com.dtcc.oval:tst:23095" />
+        </oval-def:criteria>
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="MS SQL Server 2014 SP1 + vulnerable range" operator="AND">
+      <oval-def:extend_definition comment="Microsoft SQL Server 2014 SP1 installed" definition_ref="oval:org.cisecurity:def:1493" />
+      <oval-def:criteria comment="Check for vulnerable range" operator="OR">
+        <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 12.0.4232.0" test_ref="oval:org.cisecurity:tst:2193" />
+        <oval-def:criteria comment="SQL Server 2014 SP1 CU9" operator="AND">
+          <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 12.0.4487.0" test_ref="oval:org.cisecurity:tst:2185" />
+          <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is greater than or equal to 12.0.4400.0" test_ref="oval:org.cisecurity:tst:2188" />
+        </oval-def:criteria>
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="MS SQL Server 2014 SP2 + vulnerable range" operator="AND">
+      <oval-def:extend_definition comment="Microsoft SQL Server 2014 SP2 installed" definition_ref="oval:org.cisecurity:def:1495" />
+      <oval-def:criteria comment="Check for vulnerable range" operator="OR">
+        <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 12.0.5203.0" test_ref="oval:org.cisecurity:tst:2184" />
+        <oval-def:criteria comment="SQL Server 2014 SP2 CU2" operator="AND">
+          <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 12.0.5532.0" test_ref="oval:org.cisecurity:tst:2192" />
+          <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is greater than or equal to 12.0.5400.0" test_ref="oval:org.cisecurity:tst:2187" />
+        </oval-def:criteria>
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.dtcc.oval_def_2310.xml
+++ b/repository/definitions/vulnerability/oval_com.dtcc.oval_def_2310.xml
@@ -1,0 +1,51 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.dtcc.oval:def:2310" version="0">
+  <oval-def:metadata>
+    <oval-def:title>SQL RDBMS Engine EoP vulnerability - CVE-2016-7254 (MS16-136)</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:product>Microsoft SQL Server 2012</oval-def:product>
+      <oval-def:product>Microsoft SQL Server 2014</oval-def:product>
+      <oval-def:product>Microsoft SQL Server 2016</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-7254" ref_url="http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-7254" source="CVE" />
+    <oval-def:description>Microsoft SQL Server 2012 SP2 and 2012 SP3 does not properly perform a cast of an unspecified pointer, which allows remote authenticated users to gain privileges via unknown vectors, aka "SQL RDBMS Engine Elevation of Privilege Vulnerability."</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2016-12-07T00:00:00+08:00">
+          <oval-def:contributor organization="DTCC">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria comment="MS SQL Server+ vulnerable range" operator="OR">
+    <oval-def:criteria comment="Microsoft SQL Server 2012 SP2 + vulnerable range" operator="AND">
+      <oval-def:extend_definition comment="Microsoft SQL Server 2012 SP2 is installed" definition_ref="oval:org.mitre.oval:def:29429" />
+      <oval-def:criteria comment="Check for vulnerable range" operator="OR">
+        <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 11.0.5388.0" test_ref="oval:com.dtcc.oval:tst:23090" />
+        <oval-def:criteria comment="SQL Server 2012 SP2 CU15" operator="AND">
+          <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 11.0.5676.0" test_ref="oval:com.dtcc.oval:tst:23091" />
+          <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is greater than or equal to 11.0.5500.0" test_ref="oval:com.dtcc.oval:tst:23092" />
+        </oval-def:criteria>
+      </oval-def:criteria>
+    </oval-def:criteria>
+    <oval-def:criteria comment="Microsoft SQL Server 2012 SP3 + vulnerable range" operator="AND">
+      <oval-def:extend_definition comment="Microsoft SQL Server 2012 SP3 is installed" definition_ref="oval:com.dtcc.oval:def:2019" />
+      <oval-def:criteria comment="Check for vulnerable range" operator="OR">
+        <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 11.0.6248.0" test_ref="oval:com.dtcc.oval:tst:23093" />
+        <oval-def:criteria comment="SQL Server 2012 SP3 CU6" operator="AND">
+          <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 11.0.6567.0" test_ref="oval:com.dtcc.oval:tst:23094" />
+          <oval-def:criterion comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is greater than or equal to 11.0.6300.0" test_ref="oval:com.dtcc.oval:tst:23095" />
+        </oval-def:criteria>
+      </oval-def:criteria>
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/states/windows/file_state/23000/oval_com.dtcc.oval_ste_23090.xml
+++ b/repository/states/windows/file_state/23000/oval_com.dtcc.oval_ste_23090.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 11.0.5388.0" id="oval:com.dtcc.oval:ste:23090" version="0">
+  <version datatype="version" operation="less than">11.0.5388.0</version>
+</file_state>

--- a/repository/states/windows/file_state/23000/oval_com.dtcc.oval_ste_23091.xml
+++ b/repository/states/windows/file_state/23000/oval_com.dtcc.oval_ste_23091.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 11.0.5676.0" id="oval:com.dtcc.oval:ste:23091" version="0">
+  <version datatype="version" operation="less than">11.0.5676.0</version>
+</file_state>

--- a/repository/states/windows/file_state/23000/oval_com.dtcc.oval_ste_23092.xml
+++ b/repository/states/windows/file_state/23000/oval_com.dtcc.oval_ste_23092.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is greater than or equal to 11.0.5500.0" id="oval:com.dtcc.oval:ste:23092" version="0">
+  <version datatype="version" operation="greater than or equal">11.0.5500.0</version>
+</file_state>

--- a/repository/states/windows/file_state/23000/oval_com.dtcc.oval_ste_23093.xml
+++ b/repository/states/windows/file_state/23000/oval_com.dtcc.oval_ste_23093.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 11.0.6248.0" id="oval:com.dtcc.oval:ste:23093" version="0">
+  <version datatype="version" operation="less than">11.0.6248.0</version>
+</file_state>

--- a/repository/states/windows/file_state/23000/oval_com.dtcc.oval_ste_23094.xml
+++ b/repository/states/windows/file_state/23000/oval_com.dtcc.oval_ste_23094.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 11.0.6567.0" id="oval:com.dtcc.oval:ste:23094" version="0">
+  <version datatype="version" operation="less than">11.0.6567.0</version>
+</file_state>

--- a/repository/states/windows/file_state/23000/oval_com.dtcc.oval_ste_23095.xml
+++ b/repository/states/windows/file_state/23000/oval_com.dtcc.oval_ste_23095.xml
@@ -1,0 +1,3 @@
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is greater than or equal to 11.0.6300.0" id="oval:com.dtcc.oval:ste:23095" version="0">
+  <version datatype="version" operation="greater than or equal">11.0.6300.0</version>
+</file_state>

--- a/repository/states/windows/registry_state/20000/oval_com.dtcc.oval_ste_20190.xml
+++ b/repository/states/windows/registry_state/20000/oval_com.dtcc.oval_ste_20190.xml
@@ -1,0 +1,3 @@
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State holds if the version is less than 11.0.6020.0" id="oval:com.dtcc.oval:ste:20190" version="0">
+  <value datatype="version" operation="less than">11.0.6020.0</value>
+</registry_state>

--- a/repository/states/windows/registry_state/20000/oval_com.dtcc.oval_ste_20191.xml
+++ b/repository/states/windows/registry_state/20000/oval_com.dtcc.oval_ste_20191.xml
@@ -1,0 +1,3 @@
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches if the version is greater than or equal to 11.0.6020.0" id="oval:com.dtcc.oval:ste:20191" version="1">
+  <value datatype="version" operation="greater than or equal">11.0.6020.0</value>
+</registry_state>

--- a/repository/tests/windows/file_test/23000/oval_com.dtcc.oval_tst_23090.xml
+++ b/repository/tests/windows/file_test/23000/oval_com.dtcc.oval_tst_23090.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 11.0.5388.0" id="oval:com.dtcc.oval:tst:23090" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:41803" />
+  <state state_ref="oval:com.dtcc.oval:ste:23090" />
+</file_test>

--- a/repository/tests/windows/file_test/23000/oval_com.dtcc.oval_tst_23091.xml
+++ b/repository/tests/windows/file_test/23000/oval_com.dtcc.oval_tst_23091.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 11.0.5676.0" id="oval:com.dtcc.oval:tst:23091" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:41803" />
+  <state state_ref="oval:com.dtcc.oval:ste:23091" />
+</file_test>

--- a/repository/tests/windows/file_test/23000/oval_com.dtcc.oval_tst_23092.xml
+++ b/repository/tests/windows/file_test/23000/oval_com.dtcc.oval_tst_23092.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is greater than or equal to 11.0.5500.0" id="oval:com.dtcc.oval:tst:23092" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:41803" />
+  <state state_ref="oval:com.dtcc.oval:ste:23092" />
+</file_test>

--- a/repository/tests/windows/file_test/23000/oval_com.dtcc.oval_tst_23093.xml
+++ b/repository/tests/windows/file_test/23000/oval_com.dtcc.oval_tst_23093.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 11.0.6248.0" id="oval:com.dtcc.oval:tst:23093" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:41803" />
+  <state state_ref="oval:com.dtcc.oval:ste:23093" />
+</file_test>

--- a/repository/tests/windows/file_test/23000/oval_com.dtcc.oval_tst_23094.xml
+++ b/repository/tests/windows/file_test/23000/oval_com.dtcc.oval_tst_23094.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is less than 11.0.6567.0" id="oval:com.dtcc.oval:tst:23094" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:41803" />
+  <state state_ref="oval:com.dtcc.oval:ste:23094" />
+</file_test>

--- a/repository/tests/windows/file_test/23000/oval_com.dtcc.oval_tst_23095.xml
+++ b/repository/tests/windows/file_test/23000/oval_com.dtcc.oval_tst_23095.xml
@@ -1,0 +1,4 @@
+<file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of Microsoft.sqlserver.chainer.infrastructure.dll is greater than or equal to 11.0.6300.0" id="oval:com.dtcc.oval:tst:23095" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:41803" />
+  <state state_ref="oval:com.dtcc.oval:ste:23095" />
+</file_test>

--- a/repository/tests/windows/registry_test/140000/oval_org.mitre.oval_tst_140967.xml
+++ b/repository/tests/windows/registry_test/140000/oval_org.mitre.oval_tst_140967.xml
@@ -1,4 +1,5 @@
 <registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if SQL Server 2012 SP2 is installed" id="oval:org.mitre.oval:tst:140967" version="1">
   <object object_ref="oval:org.mitre.oval:obj:11792" />
   <state state_ref="oval:org.mitre.oval:ste:39372" />
+  <state state_ref="oval:com.dtcc.oval:ste:20190" />
 </registry_test>

--- a/repository/tests/windows/registry_test/2000/oval_com.dtcc.oval_tst_2019.xml
+++ b/repository/tests/windows/registry_test/2000/oval_com.dtcc.oval_tst_2019.xml
@@ -1,0 +1,4 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="Check if SQL Server 2012 SP3 is installed" id="oval:com.dtcc.oval:tst:2019" version="0">
+  <object object_ref="oval:org.mitre.oval:obj:11792" />
+  <state state_ref="oval:com.dtcc.oval:ste:20191" />
+</registry_test>


### PR DESCRIPTION
Updated oval_org.mitre.oval_tst_140967.xml and added less than state to
properly check MS SQL 2012 SP2 version.

MS SQL 2012 SP3
CVE-2016-7253
CVE-2016-7254