### PR TITLE
Updated ImageMagick Inventory and CVE-2016-3716-7

### DIFF
--- a/repository/definitions/vulnerability/oval_com.dtcc.oval_def_2324.xml
+++ b/repository/definitions/vulnerability/oval_com.dtcc.oval_def_2324.xml
@@ -1,0 +1,39 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.dtcc.oval:def:2324" version="0">
+  <oval-def:metadata>
+    <oval-def:title>MSL coder vulnerability in ImageMagick before 6.9.3-10 and 7.x before 7.0.1-1 - CVE-2016-3716</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows XP</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2000</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>ImageMagick</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-3716" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3716" source="CVE" />
+    <oval-def:description>The MSL coder in ImageMagick before 6.9.3-10 and 7.x before 7.0.1-1 allows remote attackers to move arbitrary files via a crafted image.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2016-12-08T00:00:00+08:00">
+          <oval-def:contributor organization="DTCC">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="ImageMagick is installed" definition_ref="oval:org.mitre.oval:def:12429" />
+    <oval-def:criteria comment="Vulnerable version" operator="OR">
+      <oval-def:criterion comment="Check if ImageMagick is 6.9.3-9 or previous versions" test_ref="oval:com.dtcc.oval:tst:23230" />
+      <oval-def:criterion comment="Check if ImageMagick is 7.0.0-0 or 7.0.1-0 versions" test_ref="oval:com.dtcc.oval:tst:23231" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/definitions/vulnerability/oval_com.dtcc.oval_def_2325.xml
+++ b/repository/definitions/vulnerability/oval_com.dtcc.oval_def_2325.xml
@@ -1,0 +1,39 @@
+<oval-def:definition xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" class="vulnerability" id="oval:com.dtcc.oval:def:2325" version="0">
+  <oval-def:metadata>
+    <oval-def:title>LABEL coder vulnerability in ImageMagick before 6.9.3-10 and 7.x before 7.0.1-1 - CVE-2016-3717</oval-def:title>
+    <oval-def:affected family="windows">
+      <oval-def:platform>Microsoft Windows XP</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Vista</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 7</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 8.1</oval-def:platform>
+      <oval-def:platform>Microsoft Windows 10</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2000</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2003</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2008 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2012 R2</oval-def:platform>
+      <oval-def:platform>Microsoft Windows Server 2016</oval-def:platform>
+      <oval-def:product>ImageMagick</oval-def:product>
+    </oval-def:affected>
+    <oval-def:reference ref_id="CVE-2016-3717" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3717" source="CVE" />
+    <oval-def:description>The LABEL coder in ImageMagick before 6.9.3-10 and 7.x before 7.0.1-1 allows remote attackers to read arbitrary files via a crafted image.</oval-def:description>
+    <oval-def:oval_repository>
+      <oval-def:dates>
+        <oval-def:submitted date="2016-12-08T00:00:00+08:00">
+          <oval-def:contributor organization="DTCC">Jeff Albert</oval-def:contributor>
+        </oval-def:submitted>
+      </oval-def:dates>
+      <oval-def:status>INITIAL SUBMISSION</oval-def:status>
+      <oval-def:min_schema_version>5.10</oval-def:min_schema_version>
+    </oval-def:oval_repository>
+  </oval-def:metadata>
+  <oval-def:criteria>
+    <oval-def:extend_definition comment="ImageMagick is installed" definition_ref="oval:org.mitre.oval:def:12429" />
+    <oval-def:criteria comment="Vulnerable version" operator="OR">
+      <oval-def:criterion comment="Check if ImageMagick is 6.9.3-9 or previous versions" test_ref="oval:com.dtcc.oval:tst:23230" />
+      <oval-def:criterion comment="Check if ImageMagick is 7.0.0-0 or 7.0.1-0 versions" test_ref="oval:com.dtcc.oval:tst:23231" />
+    </oval-def:criteria>
+  </oval-def:criteria>
+</oval-def:definition>

--- a/repository/objects/windows/registry_object/23000/oval_com.dtcc.oval_obj_23230.xml
+++ b/repository/objects/windows/registry_object/23000/oval_com.dtcc.oval_obj_23230.xml
@@ -1,0 +1,6 @@
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" comment="Object holds the 32- and 64-bit install path of ImageMagick" id="oval:com.dtcc.oval:obj:23230" version="0">
+  <oval-def:set>
+    <oval-def:object_reference>oval:com.dtcc.oval:obj:23231</oval-def:object_reference>
+    <oval-def:object_reference>oval:org.mitre.oval:obj:15602</oval-def:object_reference>
+  </oval-def:set>
+</registry_object>

--- a/repository/objects/windows/registry_object/23000/oval_com.dtcc.oval_obj_23231.xml
+++ b/repository/objects/windows/registry_object/23000/oval_com.dtcc.oval_obj_23231.xml
@@ -1,0 +1,6 @@
+<registry_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="Object holds if ImageMagick is installed (32-bit)" id="oval:com.dtcc.oval:obj:23231" version="0">
+  <behaviors windows_view="32_bit" />
+  <hive>HKEY_LOCAL_MACHINE</hive>
+  <key operation="pattern match">^SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\ImageMagick .*$</key>
+  <name>DisplayName</name>
+</registry_object>

--- a/repository/states/windows/registry_state/23000/oval_org.mitre.oval_ste_23230.xml
+++ b/repository/states/windows/registry_state/23000/oval_org.mitre.oval_ste_23230.xml
@@ -1,0 +1,3 @@
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches if ImageMagick is installed" id="oval:org.mitre.oval:ste:23230" version="0">
+  <value operation="pattern match">^ImageMagick 6.[0-9].[1-3]-[0-9] .*$</value>
+</registry_state>

--- a/repository/states/windows/registry_state/23000/oval_org.mitre.oval_ste_23231.xml
+++ b/repository/states/windows/registry_state/23000/oval_org.mitre.oval_ste_23231.xml
@@ -1,0 +1,3 @@
+<registry_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches if ImageMagick is installed" id="oval:org.mitre.oval:ste:23231" version="0">
+  <value operation="pattern match">^ImageMagick 7.0.[0-1]-0 .*$</value>
+</registry_state>

--- a/repository/tests/windows/registry_test/23000/oval_com.dtcc.oval_tst_23230.xml
+++ b/repository/tests/windows/registry_test/23000/oval_com.dtcc.oval_tst_23230.xml
@@ -1,0 +1,4 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the ImageMagick is equal to 6.9.3-9 or previous versions" id="oval:com.dtcc.oval:tst:23230" version="0">
+  <object object_ref="oval:com.dtcc.oval:obj:23230" />
+  <state state_ref="oval:org.mitre.oval:ste:23230" />
+</registry_test>

--- a/repository/tests/windows/registry_test/23000/oval_com.dtcc.oval_tst_23231.xml
+++ b/repository/tests/windows/registry_test/23000/oval_com.dtcc.oval_tst_23231.xml
@@ -1,0 +1,4 @@
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if the version of ImageMagick is equal 7.0.0-0 or 7.0.1-0" id="oval:com.dtcc.oval:tst:23231" version="0">
+  <object object_ref="oval:com.dtcc.oval:obj:23230" />
+  <state state_ref="oval:org.mitre.oval:ste:23231" />
+</registry_test>

--- a/repository/tests/windows/registry_test/42000/oval_org.mitre.oval_tst_42296.xml
+++ b/repository/tests/windows/registry_test/42000/oval_org.mitre.oval_tst_42296.xml
@@ -1,4 +1,4 @@
-<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if ImageMagick is installed" id="oval:org.mitre.oval:tst:42296" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:15602" />
+<registry_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="all" check_existence="at_least_one_exists" comment="Check if ImageMagick is installed" id="oval:org.mitre.oval:tst:42296" version="2">
+  <object object_ref="oval:com.dtcc.oval:obj:23230" />
   <state state_ref="oval:org.mitre.oval:ste:12300" />
 </registry_test>


### PR DESCRIPTION
Updated ImageMagick Object to check both 32 and 64 bit installations.

New Vulnerability Definitions:
CVE-2016-3716
CVE-2016-3717