### PR TITLE
Update_oval_org.cisecurity_ste_564.xml

### DIFF
--- a/repository/states/windows/file_state/0000/oval_org.cisecurity_ste_564.xml
+++ b/repository/states/windows/file_state/0000/oval_org.cisecurity_ste_564.xml
@@ -1,3 +1,3 @@
-<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches if the version is less than or equal 8.0.7601.17000" id="oval:org.cisecurity:ste:564" version="1">
+<file_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" comment="State matches if the version is greater than or equal 8.0.7601.17000" id="oval:org.cisecurity:ste:564" version="1">
   <version datatype="version" operation="greater than or equal">8.0.7601.17000</version>
 </file_state>


### PR DESCRIPTION
Updated oval:org.cisecurity:ste:564 comment to reflect the correct
operation value (i.e. greater than).